### PR TITLE
UI: changes to window management during hide to tray

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5066,3 +5066,10 @@ void OBSBasic::SystemTray(bool firstStarted)
 	else
 		showHide->setText(QTStr("Basic.SystemTray.Show"));
 }
+
+bool OBSBasic::sysTrayMinimizeToTray()
+{
+	return config_get_bool(GetGlobalConfig(),
+		"BasicWindow", "SysTrayMinimizeToTray");
+}
+

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4908,10 +4908,19 @@ void OBSBasic::on_actionScaleOutput_triggered()
 
 void OBSBasic::SetShowing(bool showing)
 {
+	//hide
 	if (!showing && isVisible()) {
 		config_set_string(App()->GlobalConfig(),
 			"BasicWindow", "geometry",
 			saveGeometry().toBase64().constData());
+		
+		//hide all visible child dialogs
+		if (!list_of_VisibleDialogs.isEmpty()) {
+			foreach(QDialog* cur_dialog, list_of_VisibleDialogs) {
+				cur_dialog->hide();
+			}
+		}
+
 
 		if (showHide)
 			showHide->setText(QTStr("Basic.SystemTray.Show"));
@@ -4922,6 +4931,7 @@ void OBSBasic::SetShowing(bool showing)
 
 		setVisible(false);
 
+	//show
 	} else if (showing && !isVisible()) {
 		
 		//If the window is not visible(i.e. isVisible() returns false),
@@ -4939,7 +4949,27 @@ void OBSBasic::SetShowing(bool showing)
 			EnablePreviewDisplay(true);
 
 		setVisible(true);
+		
+		//show all child dialogs that was visible earlier
+		if (!list_of_VisibleDialogs.isEmpty()) {
+			foreach(QDialog* cur_dialog, list_of_VisibleDialogs) {
+				cur_dialog->show();
+			}
+		}
 	}
+}
+
+void OBSBasic::ToggleShowHide()
+{
+	bool showing = isVisible();
+	if (showing) {
+		//make check for modal dialogs
+		EnumDialogs();
+		if (!list_of_ModalDialogs.isEmpty() ||
+			!list_of_VisibleMBoxes.isEmpty())
+				return;
+	}
+	SetShowing(!showing);
 }
 
 void OBSBasic::SystemTrayInit()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2703,6 +2703,28 @@ void OBSBasic::CloseDialogs()
 	}
 }
 
+void OBSBasic::EnumDialogs()
+{
+	list_of_VisibleDialogs.clear();
+	list_of_ModalDialogs.clear();
+	//fill list of Visible dialogs and Modal dialogs
+	QList<QDialog*> allDialogs = this->findChildren<QDialog*>();
+	foreach(QDialog* cur_dialog, allDialogs) {
+		if (cur_dialog->isVisible())
+			list_of_VisibleDialogs.append(cur_dialog);
+		if (cur_dialog->isModal())
+			list_of_ModalDialogs.append(cur_dialog);
+	}
+
+	list_of_VisibleMBoxes.clear();
+	//fill list of Visible message boxes
+	QList<QMessageBox*> allMessageBoxes = this->findChildren<QMessageBox*>();
+	foreach(QMessageBox* cur_MBox, allMessageBoxes) {
+		if (cur_MBox->isVisible())
+			list_of_VisibleMBoxes.append(cur_MBox);
+	}
+}
+
 void OBSBasic::ClearSceneData()
 {
 	disableSaving++;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -325,6 +325,8 @@ private:
 	
 	bool sysTrayMinimizeToTray();
 	
+	void EnumDialogs();
+	
 	QList<QDialog*> list_of_VisibleDialogs;
 	QList<QDialog*> list_of_ModalDialogs;
 	QList<QMessageBox*> list_of_VisibleMBoxes; //always modal

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -323,11 +323,7 @@ private:
 
 	void ReplayBufferClicked();
 	
-	inline bool sysTrayMinimizeToTray() const
-	{
-		return config_get_bool(GetGlobalConfig(),
-			"BasicWindow", "SysTrayMinimizeToTray");
-	}
+	bool sysTrayMinimizeToTray();
 	
 	QList<QDialog*> list_of_VisibleDialogs;
 	QList<QDialog*> list_of_ModalDialogs;
@@ -403,15 +399,7 @@ private slots:
 	void IconActivated(QSystemTrayIcon::ActivationReason reason);
 	void SetShowing(bool showing);
 
-	inline void ToggleShowHide()
-	{
-		bool showing = isVisible();
-		if (disableHiding && showing)
-			return;
-		if (showing)
-			CloseDialogs();
-		SetShowing(!showing);
-	}
+	void ToggleShowHide();
 
 private:
 	/* OBS Callbacks */

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -38,6 +38,8 @@
 
 #include <QPointer>
 
+#include <QMessageBox>
+
 class QListWidgetItem;
 class VolControl;
 class QNetworkReply;
@@ -326,6 +328,10 @@ private:
 		return config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "SysTrayMinimizeToTray");
 	}
+	
+	QList<QDialog*> list_of_VisibleDialogs;
+	QList<QDialog*> list_of_ModalDialogs;
+	QList<QMessageBox*> list_of_VisibleMBoxes; //always modal
 
 public slots:
 	void StartStreaming();


### PR DESCRIPTION
New behavior:
1. Hiding to tray is disabled when any modal dialog or message box is visible;
2. All child dialogs preserved upon hiding (don't forced to close);

Possible workaround for: https://obsproject.com/mantis/view.php?id=625