### PR TITLE
UI: preserve projectors on hide to tray

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4912,13 +4912,6 @@ void OBSBasic::SetShowing(bool showing)
 			"BasicWindow", "geometry",
 			saveGeometry().toBase64().constData());
 		
-		/* TODO - preserve projectors */
-		//delete projectors on hide
-		for (QPointer<QWidget> &projector : projectors) {
-			delete projector;
-			projector.clear();
-		}
-		
 		//hide all visible child dialogs
 		VisibleDialogsPos.clear();
 		if (!list_of_VisibleDialogs.isEmpty()) {

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -19,6 +19,9 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_)
 {
 	setAttribute(Qt::WA_DeleteOnClose, true);
 
+	//disable application quit when last window closed
+	setAttribute(Qt::WA_QuitOnClose, false);
+
 	installEventFilter(CreateShortcutFilter());
 
 	auto addDrawCallback = [this] ()


### PR DESCRIPTION
Gives independent control to Projector's close when hiding to tray.

Qt::WA_QuitOnClose for Projector is required if application quitOnLastWindowClosed() not enabled.