### PR TITLE
 libobs: Remove release() double

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6146,6 +6146,7 @@ void OBSBasic::on_actionPasteFilters_triggered()
 		return;
 
 	obs_source_copy_filters(dstSource, source);
+	obs_source_release(source);
 }
 
 void OBSBasic::on_autoConfigure_triggered()

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -425,8 +425,6 @@ void obs_source_copy_filters(obs_source_t *dst, obs_source_t *src)
 	duplicate_filters(dst, src, dst->context.private ?
 					OBS_SCENE_DUP_PRIVATE_COPY :
 					OBS_SCENE_DUP_COPY);
-
-	obs_source_release(src);
 }
 
 obs_source_t *obs_source_duplicate(obs_source_t *source,


### PR DESCRIPTION
Release() not desirable when used in different calls.