### PR TITLE
UI: Add ability to make numbered recordings

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -645,6 +645,7 @@ Basic.Settings.Output.Adv.Recording.Type.FFmpegOutput="Custom Output (FFmpeg)"
 Basic.Settings.Output.Adv.Recording.UseStreamEncoder="(Use stream encoder)"
 Basic.Settings.Output.Adv.Recording.Filename="Filename Formatting"
 Basic.Settings.Output.Adv.Recording.OverwriteIfExists="Overwrite if file exists"
+Basic.Settings.Output.Adv.Recording.UseLocalCounter="Numbering per session"
 Basic.Settings.Output.Adv.FFmpeg.Type="FFmpeg Output Type"
 Basic.Settings.Output.Adv.FFmpeg.Type.URL="Output to URL"
 Basic.Settings.Output.Adv.FFmpeg.Type.RecordToFile="Output to File"
@@ -671,7 +672,8 @@ Basic.Settings.Output.Adv.FFmpeg.IgnoreCodecCompat="Show all codecs (even if pot
 FilenameFormatting.completer="%CCYY-%MM-%DD %hh-%mm-%ss\n%YY-%MM-%DD %hh-%mm-%ss\n%Y-%m-%d %H-%M-%S\n%y-%m-%d %H-%M-%S\n%a %Y-%m-%d %H-%M-%S\n%A %Y-%m-%d %H-%M-%S\n%Y-%b-%d %H-%M-%S\n%Y-%B-%d %H-%M-%S\n%Y-%m-%d %I-%M-%S-%p\n%Y-%m-%d %H-%M-%S-%z\n%Y-%m-%d %H-%M-%S-%Z"
 
 # basic mode 'output' settings - advanced section - recording subsection - TT
-FilenameFormatting.TT="%CCYY	Year, four digits\n%YY		Year, last two digits (00-99)\n%MM		Month as a decimal number (01-12)\n%DD		Day of the month, zero-padded (01-31)\n%hh		Hour in 24h format (00-23)\n%mm		Minute (00-59)\n%ss		Second (00-61)\n%%		A % sign\n%a		Abbreviated weekday name\n%A		Full weekday name\n%b		Abbreviated month name\n%B		Full month name\n%d		Day of the month, zero-padded (01-31)\n%H		Hour in 24h format (00-23)\n%I		Hour in 12h format (01-12)\n%m		Month as a decimal number (01-12)\n%M		Minute (00-59)\n%p		AM or PM designation\n%S		Second (00-61)\n%y		Year, last two digits (00-99)\n%Y		Year\n%z		ISO 8601 offset from UTC or timezone\n		name or abbreviation\n%Z		Timezone name or abbreviation\n"
+FilenameFormatting.TT="%CCYY	Year, four digits\n%YY		Year, last two digits (00-99)\n%MM		Month as a decimal number (01-12)\n%DD		Day of the month, zero-padded (01-31)\n%hh		Hour in 24h format (00-23)\n%mm		Minute (00-59)\n%ss		Second (00-61)\n%%		A % sign\n%a		Abbreviated weekday name\n%A		Full weekday name\n%b		Abbreviated month name\n%B		Full month name\n%d		Day of the month, zero-padded (01-31)\n%H		Hour in 24h format (00-23)\n%I		Hour in 12h format (01-12)\n%m		Month as a decimal number (01-12)\n%M		Minute (00-59)\n%p		AM or PM designation\n%S		Second (00-61)\n%y		Year, last two digits (00-99)\n%Y		Year\n%z		ISO 8601 offset from UTC or timezone\n		name or abbreviation\n%Z		Timezone name or abbreviation\n\n%%set[str1,...,strN]\n		User's set of the text strings\n		separated with ',' (comma)\n\n%%d		Decimal\n%%0nd	Decimal zero-padded, n = [0-9]\n"
+LocalCounter.TT="If checked, recording's counter resets each time the application starts.\n\nFor Replays, when not checked, the number is sum of the recording's number and current replay."
 
 # basic mode 'video' settings
 Basic.Settings.Video="Video"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -4081,11 +4081,22 @@
                     <widget class="QLineEdit" name="filenameFormatting"/>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QCheckBox" name="overwriteIfExists">
-                     <property name="text">
-                      <string>Basic.Settings.Output.Adv.Recording.OverwriteIfExists</string>
-                     </property>
-                    </widget>
+                    <layout class="QHBoxLayout" name="horizontalLayoutWrLc">
+                     <item>
+                      <widget class="QCheckBox" name="overwriteIfExists">
+                       <property name="text">
+                        <string>Basic.Settings.Output.Adv.Recording.OverwriteIfExists</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="useLocalCounter">
+                       <property name="text">
+                        <string>Basic.Settings.Output.Adv.Recording.UseLocalCounter</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                    <item row="2" column="1">
                     <layout class="QHBoxLayout" name="horizontalLayout_14">
@@ -4514,6 +4525,7 @@
   <tabstop>monitoringDevice</tabstop>
   <tabstop>filenameFormatting</tabstop>
   <tabstop>overwriteIfExists</tabstop>
+  <tabstop>useLocalCounter</tabstop>
   <tabstop>simpleRBPrefix</tabstop>
   <tabstop>simpleRBSuffix</tabstop>
   <tabstop>streamDelayEnable</tabstop>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1205,6 +1205,14 @@ string GenerateTimeDateFilename(const char *extension, bool noSpace)
 	return string(file);
 }
 
+string GenerateNumberedString(const int32_t recType, int32_t number,
+		const char *format)
+{
+	BPtr<char> numname = os_numbered_string(recType, number, format);
+
+	return string(numname);
+}
+
 string GenerateSpecifiedFilename(const char *extension, bool noSpace,
 		const char *format)
 {

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -36,6 +36,8 @@
 std::string CurrentTimeString();
 std::string CurrentDateTimeString();
 std::string GenerateTimeDateFilename(const char *extension, bool noSpace=false);
+std::string GenerateNumberedString(const int32_t recType, int32_t number,
+					const char *format);
 std::string GenerateSpecifiedFilename(const char *extension, bool noSpace,
 					const char *format);
 QObject *CreateShortcutFilter();

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1636,7 +1636,7 @@ bool AdvancedOutput::StartRecording()
 
 		string sf = GenerateSpecifiedFilename(recFormat, noSpace,
 				filenameFormat);
-		strPath += GenerateNumberedString(1, numRecOut, sf.c_str())
+		strPath += GenerateNumberedString(1, numRecOut, sf.c_str());
 		ensure_directory_exists(strPath);
 		if (!overwriteIfExists)
 			FindBestFilename(strPath, noSpace);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -429,6 +429,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #endif
 	HookWidget(ui->filenameFormatting,   EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->overwriteIfExists,    CHECK_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->useLocalCounter,      CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->simpleRBPrefix,       EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->simpleRBSuffix,       EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->streamDelayEnable,    CHECK_CHANGED,  ADV_CHANGED);
@@ -1550,6 +1551,7 @@ void OBSBasicSettings::LoadAdvOutputStreamingSettings()
 	specCompleter->setFilterMode(Qt::MatchContains);
 	ui->filenameFormatting->setCompleter(specCompleter);
 	ui->filenameFormatting->setToolTip(QTStr("FilenameFormatting.TT"));
+	ui->useLocalCounter->setToolTip(QTStr("LocalCounter.TT"));
 
 	switch (trackIndex) {
 	case 1: ui->advOutTrack1->setChecked(true); break;
@@ -2192,6 +2194,8 @@ void OBSBasicSettings::LoadAdvancedSettings()
 			"FilenameFormatting");
 	bool overwriteIfExists = config_get_bool(main->Config(), "Output",
 			"OverwriteIfExists");
+	bool useLocalCounter = config_get_bool(main->Config(), "Output",
+			"UseLocalCounter");
 	const char *bindIP = config_get_string(main->Config(), "Output",
 			"BindIP");
 	const char *rbPrefix = config_get_string(main->Config(), "SimpleOutput",
@@ -2216,6 +2220,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 
 	ui->filenameFormatting->setText(filename);
 	ui->overwriteIfExists->setChecked(overwriteIfExists);
+	ui->useLocalCounter->setChecked(useLocalCounter);
 	ui->simpleRBPrefix->setText(rbPrefix);
 	ui->simpleRBSuffix->setText(rbSuffix);
 
@@ -2815,6 +2820,7 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveEdit(ui->simpleRBPrefix, "SimpleOutput", "RecRBPrefix");
 	SaveEdit(ui->simpleRBSuffix, "SimpleOutput", "RecRBSuffix");
 	SaveCheckBox(ui->overwriteIfExists, "Output", "OverwriteIfExists");
+	SaveCheckBox(ui->useLocalCounter, "Output", "UseLocalCounter");
 	SaveCheckBox(ui->streamDelayEnable, "Output", "DelayEnable");
 	SaveSpinBox(ui->streamDelaySec, "Output", "DelaySec");
 	SaveCheckBox(ui->streamDelayPreserve, "Output", "DelayPreserve");

--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -26,6 +26,12 @@
 #include "utf8.h"
 #include "dstr.h"
 
+int32_t usrC = 0; //counter for the "%set" items in filenaming
+int32_t usrCR = 0; //counter for the "%set" items in filenaming replays
+
+//valid decimal padded formats
+char dfrmts[] = "%00d%01d%02d%03d%04d%05d%06d%07d%08d%09d";
+
 FILE *os_wfopen(const wchar_t *path, const char *mode)
 {
 	FILE *file = NULL;

--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -774,3 +774,148 @@ char *os_generate_formatted_filename(const char *extension, bool space,
 
 	return sf.array;
 }
+
+char *os_numbered_string(const int32_t recType, int32_t number,
+		const char *format)
+{
+	/*
+		recType bitfield definitions:
+		-----------------------------
+		0 - unknown type;
+		1 - local recording;
+		2 - replay save;
+		4... - reserved, same as 0;
+	*/
+
+	//in case of unknown type - only first element of the "set" is valid
+	int32_t usrCounter = 1; //to manage "set" itterations
+
+	if (recType & 0x01)
+		usrCounter = ++usrC;
+	if (recType & 0x02) {
+		usrCounter = ++usrCR;
+		number += usrCounter;
+	}
+
+	struct dstr numf;
+	dstr_init_copy(&numf, format);
+
+	//skip empty string
+	if (numf.len == 0)
+		return numf.array;
+
+	char *pfrmt; //pointer to format: "%set", "%d"...
+	size_t frmtL; //length without null
+	size_t frmtPos; //offset of the format "%set", "%d"...
+
+	pfrmt = strstr(numf.array, "%set");
+
+	//any valid "set" format specifier has 6 signs: %set[]
+	while (pfrmt) {
+		frmtL = strlen(pfrmt);
+		frmtPos = numf.len - frmtL;
+
+		char *start = strpbrk(pfrmt, "[");
+		char *end = strpbrk(pfrmt, "]");
+
+		if ((start) && (end) && (start < end)) {
+			size_t startL, endL; //length without null
+			startL = strlen(start);
+			endL = strlen(end);
+
+			struct dstr usrSt; //user's set
+			dstr_init(&usrSt);
+			dstr_ncopy(&usrSt, start + 1, startL - endL);
+			usrSt.array[startL - endL - 1] = ','; //replace "]"
+
+			size_t itemsN = 0; //number of items
+
+			//at least one empty item always exist
+			char *p_ch = strpbrk(usrSt.array, ",");
+			while (p_ch) {
+				++itemsN;
+				p_ch = strpbrk(p_ch + 1, ",");
+			}
+
+			//if (itemsN == 0) itemsN = 1; //never executed
+
+			//find item index in current "set" (use cycled "set")
+			int32_t itemIdx = usrCounter % itemsN;
+			if (itemIdx == 0)
+				itemIdx = (int32_t)itemsN;
+
+			size_t itemL; //item length
+			size_t itemPos = 0; //item offset
+
+			//get item pointer and length according to index
+			//including empty items: "100,20abc0,,30,"
+			itemL = strcspn(usrSt.array, ",");
+			--itemIdx;
+			while (itemIdx) {
+				itemPos = itemPos + itemL + 1;
+				itemL = strcspn(usrSt.array + itemPos, ",");
+				--itemIdx;
+			}
+
+			//shorten the usrSt.array overall length to
+			//the current item, by forcing null-terminating
+			usrSt.array[itemPos + itemL] = 0;
+
+			replace_text(&numf, frmtPos, frmtL - endL + 1,
+					usrSt.array + itemPos);
+
+			dstr_free(&usrSt);
+		}
+		//try next possible format element
+		pfrmt = strstr(numf.array + frmtPos + 4, "%set");
+	}
+
+	pfrmt = strstr(numf.array, "%");
+
+	while (pfrmt) {
+		//skip "%%"
+		if (pfrmt[1] != '%') {
+			frmtL = strlen(pfrmt);
+			frmtPos = numf.len - frmtL;
+
+			//let's try padded format
+			char chkFmt[] = "%00d";
+
+			if (frmtL > 3) {
+				chkFmt[1] = pfrmt[1];
+				chkFmt[2] = pfrmt[2];
+				chkFmt[3] = pfrmt[3];
+
+				if (strstr(dfrmts, chkFmt)) {
+					//"%0Xd..." - padded
+
+					char chrs[12] = {0}; //32bit+sign+null
+					snprintf(chrs, sizeof(chrs), chkFmt,
+							number);
+
+					replace_text(&numf, frmtPos, 4, chrs);
+
+					goto next_frmt;
+				}
+			}
+
+			if ((frmtL > 1) && (pfrmt[1] == 'd')) {
+				//"%d..." - non-padded
+				char chrs[12] = {0}; //32bit + sign + null
+				snprintf(chrs, sizeof(chrs), "%d", number);
+
+				replace_text(&numf, frmtPos, 2, chrs);
+
+				//goto next_frmt;
+			}
+		}
+
+	next_frmt:
+		pfrmt = strstr(pfrmt + 1, "%"); //try next format element
+	}
+
+	if (numf.len > 255)
+		dstr_mid(&numf, &numf, 0, 255);
+
+	return numf.array;
+}

--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -794,7 +794,7 @@ char *os_numbered_string(const int32_t recType, int32_t number,
 	*/
 
 	//in case of unknown type - only first element of the "set" is valid
-	int32_t usrCounter = 1; //to manage "set" itterations
+	int32_t usrCounter = 1; //to manage "set" iterations
 
 	if (recType & 0x01)
 		usrCounter = ++usrC;
@@ -854,7 +854,6 @@ char *os_numbered_string(const int32_t recType, int32_t number,
 			size_t itemPos = 0; //item offset
 
 			//get item pointer and length according to index
-			//including empty items: "100,20abc0,,30,"
 			itemL = strcspn(usrSt.array, ",");
 			--itemIdx;
 			while (itemIdx) {
@@ -894,7 +893,6 @@ char *os_numbered_string(const int32_t recType, int32_t number,
 
 				if (strstr(dfrmts, chkFmt)) {
 					//"%0Xd..." - padded
-
 					char chrs[12] = {0}; //32bit+sign+null
 					snprintf(chrs, sizeof(chrs), chkFmt,
 							number);
@@ -907,12 +905,10 @@ char *os_numbered_string(const int32_t recType, int32_t number,
 
 			if ((frmtL > 1) && (pfrmt[1] == 'd')) {
 				//"%d..." - non-padded
-				char chrs[12] = {0}; //32bit + sign + null
+				char chrs[12] = {0}; //32bit+sign+null
 				snprintf(chrs, sizeof(chrs), "%d", number);
 
 				replace_text(&numf, frmtPos, 2, chrs);
-
-				//goto next_frmt;
 			}
 		}
 

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -169,6 +169,17 @@ EXPORT int os_safe_replace(const char *target_path, const char *from_path,
 EXPORT char *os_generate_formatted_filename(const char *extension, bool space,
 		const char *format);
 
+/*
+	recType bitfield definitions:
+	-----------------------------
+	0 - unknown type;
+	1 - local recording;
+	2 - replay save;
+	4... - reserved, same as 0;
+*/
+EXPORT char *os_numbered_string(const int32_t recType, int32_t number,
+		const char *format);
+
 struct os_inhibit_info;
 typedef struct os_inhibit_info os_inhibit_t;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -759,9 +759,12 @@ static void replay_buffer_save(struct ffmpeg_muxer *stream)
 	const char *dir = obs_data_get_string(settings, "directory");
 	const char *fmt = obs_data_get_string(settings, "format");
 	const char *ext = obs_data_get_string(settings, "extension");
+	int64_t recNumber = obs_data_get_int(settings, "recNumber");
 	bool space = obs_data_get_bool(settings, "allow_spaces");
 
-	char *filename = os_generate_formatted_filename(ext, space, fmt);
+	char *filename2 = os_generate_formatted_filename(ext, space, fmt);
+	char *filename = os_numbered_string(2, (int32_t)recNumber,
+			filename2);
 
 	dstr_copy(&stream->path, dir);
 	dstr_replace(&stream->path, "\\", "/");
@@ -769,6 +772,7 @@ static void replay_buffer_save(struct ffmpeg_muxer *stream)
 		dstr_cat_ch(&stream->path, '/');
 	dstr_cat(&stream->path, filename);
 
+	bfree(filename2);
 	bfree(filename);
 	obs_data_release(settings);
 


### PR DESCRIPTION
Also, it modifies libobs, obs-ffmpeg.

- Add ability to make numbered files names for recordings.
- Add new Filename Formatting keys:

set of user's strings separated with comma
`%%set[str1,str2,...,strN]`

decimal
`%%d`

decimal zero-padded (n = 0-9, number of zeros)
`%%0nd`

The numbering based on global/local counter of the recordings.