### PR TITLE
win-capture: Use DIP pixels for window capture

### DIFF
--- a/plugins/win-capture/dc-capture.c
+++ b/plugins/win-capture/dc-capture.c
@@ -103,6 +103,16 @@ static void draw_cursor(struct dc_capture *capture, HDC hdc, HWND window)
 		pos.x = ci->ptScreenPos.x - (int)ii.xHotspot - win_pos.x;
 		pos.y = ci->ptScreenPos.y - (int)ii.yHotspot - win_pos.y;
 
+		// get DPI for captured window
+		UINT wndDPI;
+		wndDPI = GetDForWnd(window);
+
+		if (wndDPI) {
+			// physical pixel to a DIP
+			pos.x = (long) (pos.x * 96 / (float) wndDPI);
+			pos.y = (long) (pos.y * 96 / (float) wndDPI);
+		}
+
 		DrawIconEx(hdc, pos.x, pos.y, icon, 0, 0, 0, NULL,
 				DI_NORMAL);
 

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -196,6 +196,7 @@ static void wc_tick(void *data, float seconds)
 	GetClientRect(wc->window, &rect);
 
 	// get DPI for captured window
+	UINT wndDPI;
 	wndDPI = GetDForWnd(wc->window);
 
 	if (wndDPI) {

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -195,6 +195,15 @@ static void wc_tick(void *data, float seconds)
 
 	GetClientRect(wc->window, &rect);
 
+	// get DPI for captured window
+	wndDPI = GetDForWnd(wc->window);
+
+	if (wndDPI) {
+		// physical pixel to a DIP
+		rect.bottom = (UINT) (rect.bottom * 96 / (float) wndDPI);
+		rect.right = (UINT) (rect.right * 96 / (float) wndDPI);
+	}
+
 	if (!reset_capture) {
 		wc->resize_timer += seconds;
 


### PR DESCRIPTION
Sets captured window size according to the current reported DPI setting
and adjusts cursor position.

For example, when system display scale set to 125%, the captured window
may has black bars at bottom and right under the Win10. Cursor position
always based on physical pixels, thus cursor position in the capture
becomes misaligned to the window.
This removes the black bars from the capture and recalculates cursor
position to align it to the window.