### PR TITLE
UI: Use theme colors setting for Projectors too

### DIFF
--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -3,6 +3,9 @@
 #include <QWidget>
 #include <obs.hpp>
 
+// Color format #AABBGGRR
+#define GREY_COLOR_BACKGROUND 0xFF4C4C4C
+
 class OBSQTDisplay : public QWidget {
 	Q_OBJECT
 	Q_PROPERTY(QColor displayBackgroundColor WRITE SetDisplayBackgroundColor
@@ -26,7 +29,7 @@ public:
 
 	inline obs_display_t *GetDisplay() const {return display;}
 
-	uint32_t backgroundColor;
+	uint32_t backgroundColor = GREY_COLOR_BACKGROUND;
 
 private slots:
 	void SetDisplayBackgroundColor(const QColor &color);

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -66,7 +66,6 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 		obs_display_add_draw_callback(GetDisplay(),
 				isMultiview ? OBSRenderMultiview : OBSRender,
 				this);
-		obs_display_set_background_color(GetDisplay(), 0x000000);
 	};
 
 	connect(this, &OBSQTDisplay::DisplayCreated, addDrawCallback);

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -66,7 +66,7 @@ private:
 	// argb colors
 	static const uint32_t outerColor      = 0xFFD0D0D0;
 	static const uint32_t labelColor      = 0xD91F1F1F;
-	static const uint32_t backgroundColor = 0xFF000000;
+	static const uint32_t backgroundColor = 0xFF000000; // Scene's one
 	static const uint32_t previewColor    = 0xFF00D000;
 	static const uint32_t programColor    = 0xFFD00000;
 


### PR DESCRIPTION
Don't override the theme color settings for the Projector.
If required, the background color of the projector can be changed via

OBSProjector {qproperty-...}

record placed after "OBSQTDisplay {qproperty-...}" section in the theme
file (qss).