### PR TITLE
UI: Add function to use styled tray icons

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4966,6 +4966,26 @@ static inline void ClearProcessPriority()
 #define ClearProcessPriority() do {} while(false)
 #endif
 
+void OBSBasic::setStyledTrayIcon(bool active = false)
+{
+	const QPixmap *pImg;
+	QString resource;
+
+	if (active) {
+		pImg = ui->obsTrayActiveIconDummy->pixmap();
+		resource = ":/res/images/tray_active.png";
+	} else {
+		pImg = ui->obsTrayIconDummy->pixmap();
+		resource = ":/res/images/obs.png";
+	}
+
+	/* Fallback to default resource storage if styled icon not exist */
+	if (pImg && !QIcon(*pImg).isNull())
+		trayIcon->setIcon(QIcon(*pImg));
+	else
+		trayIcon->setIcon(QIcon(resource));
+}
+
 inline void OBSBasic::OnActivate()
 {
 	if (ui->profileMenu->isEnabled()) {

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -399,6 +399,7 @@ private:
 	void ReplayBufferClicked();
 
 	bool sysTrayMinimizeToTray();
+	void setStyledTrayIcon(bool active);
 
 	void EnumDialogs();
 


### PR DESCRIPTION
Logic is next:
1) if property for UI element wasn't set then use internal resource
storage for icons;
2) if property was set but pixmap invalid then use internal resource
storage for icons;
in all other cases use pixmap value (no matter was pixmap updated or
not).