### PR TITLE
UI: Update tray icons on theme change

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -382,6 +382,8 @@ OBSBasic::OBSBasic(QWidget *parent)
 		ui->previewLabel->setHidden(true);
 	else
 		ui->previewLabel->setHidden(!labels);
+
+	connect(App(), &OBSApp::StyleChanged, this, &OBSBasic::ThemeChanged);
 }
 
 static void SaveAudioDevice(const char *name, int channel, obs_data_t *parent,
@@ -7170,3 +7172,10 @@ bool OBSBasic::ReplayBufferActive()
 		return false;
 	return outputHandler->ReplayBufferActive();
 }
+
+void OBSBasic::ThemeChanged()
+{
+	/* Update system tray icon */
+	if (trayIcon)
+		Active() ? setStyledTrayIcon(true) : setStyledTrayIcon();
+};

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -526,6 +526,8 @@ private slots:
 	void AudioMixerCopyFilters();
 	void AudioMixerPasteFilters();
 
+	void ThemeChanged();
+
 private:
 	/* OBS Callbacks */
 	static void SceneReordered(void *data, calldata_t *params);


### PR DESCRIPTION
Load new tray icon if theme specifies the icon's pixmap property.
If icon property not specified in new theme, then icon form previous
theme will be used until application restarted.